### PR TITLE
Document dependency setup for scraper run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,7 @@ Following this plan should produce the required zip output with merger-specific 
 ## Living Document Expectation
 - Update this `AGENTS.md` after completing each major task or milestone so it reflects the latest repository status.
 - Record any new issues, risks, or blockers discovered during the work so future contributors can triage them quickly.
+
+## Run Log (2025-02-14)
+- Executed `python Scrape.py --out ./test_output --max-cases 3 --query-ieo-only` after installing required Python dependencies (`requests`, `beautifulsoup4`, `lxml`, `pandas`, `openpyxl`).
+- Initial run failed because `pandas` was missing (`ModuleNotFoundError`). Installing the documented dependencies resolved the issue and the script produced the CSV/XLSX manifest, ZIP archive, and per-case download folders successfully.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,10 @@ Following this plan should produce the required zip output with merger-specific 
 ## Run Log (2025-02-14)
 - Executed `python Scrape.py --out ./test_output --max-cases 3 --query-ieo-only` after installing required Python dependencies (`requests`, `beautifulsoup4`, `lxml`, `pandas`, `openpyxl`).
 - Initial run failed because `pandas` was missing (`ModuleNotFoundError`). Installing the documented dependencies resolved the issue and the script produced the CSV/XLSX manifest, ZIP archive, and per-case download folders successfully.
+
+## Run Log (2025-02-15)
+- Attempted `python Scrape.py --out ./test_output --max-cases 1 --query-ieo-only`; run failed with `ModuleNotFoundError: No module named 'pandas'`.
+- Installed the documented dependencies via `pip install requests beautifulsoup4 lxml pandas openpyxl`.
+- Re-ran `python Scrape.py --out ./test_output --max-cases 1 --query-ieo-only`; the script reported writing the manifest CSV/XLSX and `cma_initial_orders_derogs_revocations.zip`.
+- Verified artefacts with `ls test_output`, which shows `cma_initial_orders_derogs_revocations.zip`, the manifest files, and the per-case `downloads/` folder.
+- **Reminder:** the scraper reuses the `--out` directory, so remove any old artefacts with `rm -rf ./test_output` (or choose a new `--out` path) before running fresh tests to avoid confusing previous outputs with new ones.


### PR DESCRIPTION
## Summary
- add a run log entry to AGENTS.md capturing the executed scraper command and troubleshooting steps
- note the missing pandas dependency and its resolution so future runs install the required packages first

## Testing
- python Scrape.py --out ./test_output --max-cases 3 --query-ieo-only

------
https://chatgpt.com/codex/tasks/task_e_68e4f14c7398832895e630057c196a1a