### PR TITLE
Allow legacy GOV.UK asset mirrors

### DIFF
--- a/tests/fixtures/legacy_asset_case.html
+++ b/tests/fixtures/legacy_asset_case.html
@@ -1,0 +1,13 @@
+<html>
+  <body>
+    <main>
+      <a href="https://assets.digital.cabinet-office.gov.uk/government/uploads/system/uploads/attachment_data/file/123456/legacy-derogation.pdf">
+        Legacy derogation (12.10.2015)
+      </a>
+      <a href="/government/uploads/system/uploads/attachment_data/file/654321/revocation-order.pdf">
+        Revocation order (10.01.2016)
+      </a>
+      <a href="https://example.com/not-govuk.pdf">External link</a>
+    </main>
+  </body>
+</html>

--- a/tests/test_parse_case_for_docs.py
+++ b/tests/test_parse_case_for_docs.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+import sys
+import types
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+dummy_pandas = types.ModuleType("pandas")
+
+
+class _DummyDataFrame:
+    def __init__(self, *args, **kwargs):
+        self._data = args[0] if args else []
+
+    def sort_values(self, *args, **kwargs):
+        return self
+
+    def to_csv(self, *args, **kwargs):
+        return None
+
+    def to_excel(self, *args, **kwargs):
+        return None
+
+
+dummy_pandas.DataFrame = _DummyDataFrame
+sys.modules.setdefault("pandas", dummy_pandas)
+
+import pytest
+
+from Scrape import BASE, is_govuk_asset_url, parse_case_for_docs
+
+
+class FakeResponse:
+    def __init__(self, text: str, status_code: int = 200):
+        self.text = text
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise ValueError(f"HTTP {self.status_code}")
+
+
+class FakeSession:
+    def __init__(self, html: str):
+        self.html = html
+        self.requested_urls = []
+
+    def get(self, url, headers=None, timeout=60):
+        self.requested_urls.append(url)
+        return FakeResponse(self.html)
+
+
+@pytest.fixture
+def legacy_case_html():
+    return Path("tests/fixtures/legacy_asset_case.html").read_text()
+
+
+def test_parse_case_allows_legacy_asset_hosts(legacy_case_html):
+    session = FakeSession(legacy_case_html)
+    case = {"link": "/cma-cases/example-case", "title": "Example case"}
+
+    docs = parse_case_for_docs(session, case)
+
+    assert len(docs) == 2
+    urls = {doc["doc_url"] for doc in docs}
+    assert (
+        "https://assets.digital.cabinet-office.gov.uk/government/uploads/system/uploads/attachment_data/file/123456/legacy-derogation.pdf"
+        in urls
+    )
+    assert (
+        f"{BASE}/government/uploads/system/uploads/attachment_data/file/654321/revocation-order.pdf"
+        in urls
+    )
+
+
+def test_is_govuk_asset_url_accepts_mirrors():
+    assert is_govuk_asset_url(
+        "https://assets.digital.cabinet-office.gov.uk/government/uploads/system/uploads/attachment_data/file/123456/legacy-derogation.pdf"
+    )
+    assert is_govuk_asset_url(
+        "https://assets-origin.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/654321/file.pdf"
+    )
+    assert is_govuk_asset_url(
+        "https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/000001/file.pdf"
+    )
+    assert is_govuk_asset_url("/government/uploads/system/uploads/attachment_data/file/000001/file.pdf")
+    assert is_govuk_asset_url("https://www.gov.uk/government/uploads/system/file.pdf")
+    assert not is_govuk_asset_url("https://www.gov.uk/government/news/file.pdf")
+    assert not is_govuk_asset_url("https://example.com/file.pdf")
+    assert not is_govuk_asset_url("https://malicious.publishing.service.gov.uk/file.pdf")


### PR DESCRIPTION
## Summary
- normalise GOV.UK asset host detection so legacy mirrors and /government/uploads paths are accepted when parsing case documents
- add regression coverage with a legacy case fixture exercising the broader asset host handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e67bcd67c0832881e03d32e6194ce5