### PR TITLE
Improve full text decision detection

### DIFF
--- a/Scrape.py
+++ b/Scrape.py
@@ -57,6 +57,45 @@ TYPE_RULES = [
     (re.compile(r"decision", re.I), "Decision"),
 ]
 
+FULL_TEXT_DECISION_VARIANTS = (
+    "full text decision",
+    "full text decisions",
+    "full decision text",
+    "full decision texts",
+)
+
+FULL_TEXT_DECISION_REGEXES = (
+    re.compile(r"\bfull text(?: \w+){0,4} decision(?:s)?\b"),
+    re.compile(r"\bfull decision(?: \w+){0,3} text(?:s)?\b"),
+    re.compile(r"\bdecision(?: \w+){0,3} full(?: \w+){0,3} text(?:s)?\b"),
+)
+
+
+def normalise_full_text_title(title: str) -> str:
+    """Lowercase and strip punctuation/hyphenation noise from a title."""
+
+    if not title:
+        return ""
+    lowered = title.lower()
+    # Collapse punctuation/hyphenation and multiple whitespace to single spaces.
+    lowered = re.sub(r"[^a-z0-9]+", " ", lowered)
+    return re.sub(r"\s+", " ", lowered).strip()
+
+
+def is_full_text_decision_title(title: str) -> bool:
+    """Return True when the provided title matches a full-text decision variant."""
+
+    normalised = normalise_full_text_title(title)
+    if not normalised:
+        return False
+    if any(variant in normalised for variant in FULL_TEXT_DECISION_VARIANTS):
+        return True
+    for pattern in FULL_TEXT_DECISION_REGEXES:
+        if pattern.search(normalised):
+            return True
+    return False
+
+
 CATEGORY_TO_FOLDER = {
     "Initial enforcement order": "IEOs",
     "Derogation": "Derrogations",
@@ -415,8 +454,7 @@ def main():
         if args.only_full_text_decisions:
             if r.get("doc_type") != "Decision":
                 continue
-            title = r.get("doc_title", "").lower()
-            if "full text decision" not in title:
+            if not is_full_text_decision_title(r.get("doc_title", "")):
                 continue
         unique.append(r)
 


### PR DESCRIPTION
## Summary
- normalise document titles and add regex helpers so hyphenated or reordered full text decision phrases are detected
- reuse the helper when applying the --only-full-text-decisions filter

## Testing
- `python - <<'PY'
import concurrent.futures
import requests
import Scrape

Scrape.time.sleep = lambda _=0: None

outcome_types = [
    "markets-phase-1-no-enforcement-action",
    "markets-phase-1-undertakings-in-lieu-of-reference",
    "markets-phase-1-referral",
    "mergers-phase-1-clearance",
    "mergers-phase-1-clearance-with-undertakings-in-lieu",
    "mergers-phase-1-referral",
    "mergers-phase-1-found-not-to-qualify",
    "mergers-phase-1-public-interest-interventions",
    "markets-phase-2-clearance-no-adverse-effect-on-competition",
    "markets-phase-2-adverse-effect-on-competition-leading-to-remedies",
    "markets-phase-2-decision-to-dispense-with-procedural-obligations",
    "mergers-phase-2-clearance",
    "mergers-phase-2-clearance-with-remedies",
    "mergers-phase-2-prohibition",
    "mergers-phase-2-cancellation",
]

cases = Scrape.search_all_merger_cases(requests.Session(), outcome_types=outcome_types)
print(f"discovered {len(cases)} cases")

def fetch_case(case):
    case_path = case.get("link")
    if not case_path:
        return []
    try:
        with requests.Session() as session:
            return Scrape.parse_case_for_docs(session, {"link": case_path, "title": case.get("title", "")})
    except Exception as exc:
        print(f"[warn] case {case_path}: {exc}")
        return []

records = []
with concurrent.futures.ThreadPoolExecutor(max_workers=12) as executor:
    futures = [executor.submit(fetch_case, case) for case in cases]
    for idx, fut in enumerate(concurrent.futures.as_completed(futures), 1):
        records.extend(fut.result())
        if idx % 100 == 0:
            print(f"processed {idx} case pages")

print(f"collected {len(records)} document candidates before filtering")
seen = set()
unique = []
for r in records:
    url = r.get("doc_url")
    if not url or url in seen:
        continue
    seen.add(url)
    if r.get("doc_type") != "Decision":
        continue
    if not Scrape.is_full_text_decision_title(r.get("doc_title", "")):
        continue
    unique.append(r)
print(f"full-text decisions after filtering: {len(unique)}")
PY`


------
https://chatgpt.com/codex/tasks/task_e_68e67bb5bb2883289842a92a196ca96a