### PR TITLE
Fix merger outcome slugs for full-text scraper

### DIFF
--- a/Scrape.py
+++ b/Scrape.py
@@ -352,9 +352,9 @@ def main():
     if args.all_merger_cases_with_outcomes:
         # Use the outcome types from the provided URL
         outcome_types = [
-            "markets-phase-1-no-enforcement-action",
-            "markets-phase-1-undertakings-in-lieu-of-reference",
-            "markets-phase-1-referral",
+            "mergers-phase-1-no-enforcement-action",
+            "mergers-phase-1-undertakings-in-lieu-of-reference",
+            "mergers-phase-1-referral",
             "mergers-phase-1-clearance",
             "mergers-phase-1-clearance-with-undertakings-in-lieu",
             "mergers-phase-1-referral",


### PR DESCRIPTION
## Summary
- replace the phase 1 outcome filters with the correct `mergers-phase-1-*` slugs used by the GOV.UK finder
- verified the complete list of merger outcomes against the finder configuration so no categories are missing

## Testing
- python - <<'PY'
from Scrape import search_all_merger_cases
from requests import Session
outcome_types = [
    "mergers-phase-1-no-enforcement-action",
    "mergers-phase-1-undertakings-in-lieu-of-reference",
    "mergers-phase-1-referral",
    "mergers-phase-1-clearance",
    "mergers-phase-1-clearance-with-undertakings-in-lieu",
    "mergers-phase-1-referral",
    "mergers-phase-1-found-not-to-qualify",
    "mergers-phase-1-public-interest-interventions",
    "markets-phase-2-clearance-no-adverse-effect-on-competition",
    "markets-phase-2-adverse-effect-on-competition-leading-to-remedies",
    "markets-phase-2-decision-to-dispense-with-procedural-obligations",
    "mergers-phase-2-clearance",
    "mergers-phase-2-clearance-with-remedies",
    "mergers-phase-2-prohibition",
    "mergers-phase-2-cancellation",
]
cases = search_all_merger_cases(Session(), outcome_types)
print('cases', len(cases))
PY
- python Scrape.py --out ./fulltext_sample --all-merger-cases-with-outcomes --only-full-text-decisions --max-cases 5

------
https://chatgpt.com/codex/tasks/task_e_68e67bb572f88328b863e1a79629e65c