### PR TITLE
Handle PDF links with query strings in parse_case_for_docs

### DIFF
--- a/Scrape.py
+++ b/Scrape.py
@@ -18,7 +18,7 @@ import time
 import zipfile
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin, urlparse, urlsplit
 
 import pandas as pd
 import requests
@@ -441,7 +441,8 @@ def parse_case_for_docs(session, case: Dict[str, str]) -> List[Dict[str, str]]:
         # /government/uploads/ served from www.gov.uk and legacy hosts).
         if not is_govuk_asset_url(href):
             continue
-        if not href.lower().endswith(".pdf"):
+        path = urlsplit(href).path.lower()
+        if not path.endswith(".pdf"):
             # Ignore non-PDF attachments.
             continue
         doc_type = classify_document(text, href)


### PR DESCRIPTION
## Summary
- ensure parse_case_for_docs inspects the URL path before checking the PDF suffix so query strings or fragments are supported
- add regression coverage for PDF anchors with query strings and provide a minimal pandas.Series stub for the tests

## Testing
- pytest tests/test_parse_case_for_docs.py

------
https://chatgpt.com/codex/tasks/task_e_68e6c63ccfe883288a2c63d72cd2b705