### PR TITLE
Fix derogation folder spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The script creates:
 3. **ZIP Bundle**: `cma_initial_orders_derogs_revocations.zip`
    - Contains index files (CSV & XLSX)
    - Contains PDFs organized by: `{Case}/{Category}/{filename}.pdf`
-     - Categories: `IEOs`, `Derrogations`, `Revocations`, `Other`
+    - Categories: `IEOs`, `Derogations`, `Revocations`, `Other`
 
 4. **Downloads folder**: `downloads/` (intermediate storage for PDFs)
 

--- a/Scrape.py
+++ b/Scrape.py
@@ -247,7 +247,7 @@ def should_scrape_document(case_docs: pd.DataFrame) -> pd.Series:
 
 CATEGORY_TO_FOLDER = {
     "Initial enforcement order": "IEOs",
-    "Derogation": "Derrogations",
+    "Derogation": "Derogations",
     "Revocation order": "Revocations",
     "Hold separate manager": "Hold separate manager",
     "Monitoring trustee": "Monitoring trustee",


### PR DESCRIPTION
## Summary
- correct the derogation category folder name in `Scrape.py`
- update the README output structure description to match the corrected folder name

## Testing
- pytest *(fails: DummyDataFrame used in tests lacks pandas-style methods such as `apply`)*

------
https://chatgpt.com/codex/tasks/task_e_68e6c62d811883288ca0dacccebadee5